### PR TITLE
Closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+<!-- markdownlint-disable MD024 -->
+
+# Ruff-Quickfix ChangeLog
+
+## 2024-08-18
+
+### New
+
+* Core functionality
+* CLI: click
+* Test: pytest + tox
+* Example configs
+
+## 2024-08-21
+
+### New
+
+* Nix + Home Manager Support
+* Coverage + Code Quality
+* Module entry
+
+### Changes
+
+* Optional Dependency: ruff
+* Dynamic elements in README
+
+## 2024-09-14
+
+### New
+
+* Include ruff errors/warning at the bottom
+
+### Changes
+
+* Uses json output format instead of concise
+
+### Fixes
+
+* Compatibility issues with older ruff versions #4

--- a/poetry.lock
+++ b/poetry.lock
@@ -415,6 +415,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -578,4 +595,4 @@ ruff = ["ruff"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "11f5fec2c77f8065011e205d9aebf91f6ff7efc19c8227fffa23843ff1c4f135"
+content-hash = "b6fc786f2bc0eb0d2991c955150089d8d60339a1ee046ca49bc1ed306feff93d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pytest = "^8.3.2"
 pytest-click = "^1.1.0"
 pytest-cov = "^5.0.0"
 tox = "^4.18.0"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -65,7 +66,6 @@ inline-quotes = "double"
 
 [ruff.format]
 quote-style = "double"
-
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ mkShell {
     python312Packages.pytest
     python312Packages.pytest-click
     python312Packages.pytest-cov
+    python312Packages.pytest-mock
     python312Packages.tox
   ];
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
     from click.testing import CliRunner
+    from pytest_mock.plugin import MockerFixture
 
 # Exit code constants
 EXIT_SUCCESS = 0
+EXIT_ERROR = 1
 EXIT_MISUSE = 2
 
 
@@ -84,6 +86,60 @@ def test_cli_multiple_directory(tmp_path: Path, cli_runner: CliRunner) -> None:
     assert result.output == (
         get_file_messages(file_path_0) + get_file_messages(file_path_1)
     )
+
+
+def test_cli_ruff_error(cli_runner: CliRunner, mocker: MockerFixture) -> None:
+    """
+    Test a ruff error
+
+    Args:
+        cli_runner (CliRunner): click runner
+        mocker (MockerFixture): mock module interface
+    """
+    mock_stdout = mocker.MagicMock()
+    mock_stdout.configure_mock(
+        stderr=b"This is an error!\n\n",
+        stdout=b"",
+    )
+
+    mock_run = mocker.patch("ruff_quickfix.lint.run")
+    mock_run.return_value = mock_stdout
+
+    result = cli_runner.invoke(cli, ["test"])
+
+    assert result.exit_code == EXIT_ERROR
+    msgs = [
+        "test:0:0:e:ruff message",
+        "ruff-quickfix:0:0:e:\u2001This is an error!",
+    ]
+    assert "\n".join(msgs) in result.output
+
+
+def test_cli_decode_error(cli_runner: CliRunner, mocker: MockerFixture) -> None:
+    """
+    Test a json decode error
+
+    Args:
+        cli_runner (CliRunner): click runner
+        mocker (MockerFixture): mock module interface
+    """
+    mock_stdout = mocker.MagicMock()
+    mock_stdout.configure_mock(
+        stderr=b"",
+        stdout=b"This is a decode error!\n\n",
+    )
+
+    mock_run = mocker.patch("ruff_quickfix.lint.run")
+    mock_run.return_value = mock_stdout
+
+    result = cli_runner.invoke(cli, ["test"])
+
+    assert result.exit_code == EXIT_ERROR
+    msgs = [
+        "test:0:0:e:ruff-quickfix decode error",
+        "ruff-quickfix:0:0:e:\u2001This is a decode error!",
+    ]
+    assert "\n".join(msgs) in result.output
 
 
 def test_cli_none(cli_runner: CliRunner) -> None:


### PR DESCRIPTION
1. Change output format to json
2. Uses environmental variables instead of flags for better backwards compatibility
3. Shows ruff warning/errors at the bottom of quickfix